### PR TITLE
Ridgelines demo - add navigation toggle, make rotate the default action

### DIFF
--- a/ridgeline-3D/index.html
+++ b/ridgeline-3D/index.html
@@ -33,7 +33,8 @@
       "esri/layers/ElevationLayer",
       "esri/core/promiseUtils",
       "esri/geometry/geometryEngine",
-      "esri/geometry/support/MeshMaterialMetallicRoughness"
+      "esri/geometry/support/MeshMaterialMetallicRoughness",
+      "esri/widgets/NavigationToggle/NavigationToggleViewModel"
     ], function (
       Map,
       SceneView,
@@ -47,7 +48,8 @@
       ElevationLayer,
       promiseUtils,
       geometryEngine,
-      MeshMaterialMetallicRoughness
+      MeshMaterialMetallicRoughness,
+      NavigationToggle
     ) {
       const elevationLayer = new ElevationLayer({
         url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/TopoBathy3D/ImageServer"
@@ -186,6 +188,16 @@
             date: "Fri May 15 2020 13:06:37 GMT+0200 (Central European Summer Time)"
           }
         }
+      });
+
+      // Make 'rotate' the default action
+      view.ui.components = [ "zoom", 'attribution' ];
+      navigationToggle = new NavigationToggle({
+        viewModel: {
+          view: view
+        },
+        navigationMode: 'rotate',
+        view: view
       });
 
       window.view = view;


### PR DESCRIPTION
I love the Ridgelines demo! Since it only really works in 3D mode, what about making that the default, so that dragging the mouse shows the ridgelines rather than panning?

```
      // Make 'rotate' the default action
      view.ui.components = [ "zoom", 'attribution' ];
      navigationToggle = new NavigationToggle({
        viewModel: {
          view: view
        },
        navigationMode: 'rotate',
        view: view
      });
```